### PR TITLE
Fix for upcoming stringr 1.6.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ECOTOXr
 Type: Package
 Title: Download and Extract Data from US EPA's ECOTOX Database
-Version: 1.2.2.0001
+Version: 1.2.2.0002
 Authors@R: c(person("Pepijn", "de Vries", role = c("aut", "cre", "dtc"),
     email = "pepijn.devries@outlook.com",
     comment = c(ORCID = "0000-0002-7961-6646")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-ECOTOXr v1.2.2.0001
+ECOTOXr v1.2.2.0002
 -------------
 
   * Added extra fail safe to examples

--- a/R/init.r
+++ b/R/init.r
@@ -397,8 +397,7 @@ build_ecotox_sqlite <- function(source, destination = get_ecotox_path(), write_l
         ## These should not be interpreted as table separators and will mess up the table.read call
         body       <- stringr::str_replace_all(body, "(?<=\\().+?(?=\\))", function(x){
           ## there should not be another opening bracket, double pipe or forward slash! in that case leave as is
-          if (grepl("[\\(/]", x) || grepl("||", x, fixed = T)) return(x)
-          gsub("[|]", "-", x)
+          ifelse (grepl("[\\(/]", x) | grepl("||", x, fixed = T), x, gsub("[|]", "-", x))
         })
         
         lines.read <- lines.read + length(body)


### PR DESCRIPTION
`str_replace_all()` now requires a vectorised function since that's way way faster.